### PR TITLE
Added removeSubsystem function.

### DIFF
--- a/ve_eventhandler.cpp
+++ b/ve_eventhandler.cpp
@@ -52,6 +52,11 @@ namespace VeinEvent
     emit subsystemsChanged(m_subsystems);
   }
 
+  void EventHandler::removeSubsystem(EventSystem *t_subsystem)
+  {
+    m_subsystems.removeAll(t_subsystem);
+  }
+
   void EventHandler::clearSubsystems()
   {
     if(m_subsystems.isEmpty() == false)

--- a/ve_eventhandler.h
+++ b/ve_eventhandler.h
@@ -46,6 +46,8 @@ namespace VeinEvent
     void setSubsystems(QList<EventSystem*> t_subsystems);
     void addSubsystem(EventSystem* t_subsystem);
 
+    void removeSubsystem(EventSystem* t_subsystem);
+
     void clearSubsystems();
 
   signals:

--- a/ve_eventsystem.cpp
+++ b/ve_eventsystem.cpp
@@ -18,6 +18,7 @@ namespace VeinEvent
     Q_ASSERT(t_eventHandler != nullptr);
     VF_ASSERT(m_attached == false, "EventSystem already attached");
 
+    m_eventHandler=t_eventHandler;
     QObject::connect(this,&VeinEvent::EventSystem::sigSendEvent,[=](QEvent *ev)
     {
       /// @todo add multithreaded event sending support

--- a/ve_eventsystem.h
+++ b/ve_eventsystem.h
@@ -4,22 +4,23 @@
 #include "vfevent_export.h"
 #include "globalIncludes.h"
 #include <QObject>
+#include <QPointer>
 
 class QEvent;
 
 namespace VeinEvent
 {
-  class EventHandler;
-  /**
+class EventHandler;
+/**
    * @brief Interface for event systems that can be attached to VeinEvent::EventHandler
    * @note if you want to capture events, eg. for replay, please note that the QEvent::type (see http://doc.qt.io/qt-5/qevent.html#type) of most events is not initialized in a deterministic manner
    * @todo idea: add template specialized objects that handle one particular type of event via lambda infused code
    */
-  class VFEVENT_EXPORT EventSystem : public QObject
-  {
+class VFEVENT_EXPORT EventSystem : public QObject
+{
     Q_OBJECT
 
-  public:
+public:
     explicit EventSystem(QObject *t_parent=nullptr);
     ~EventSystem() {}
 
@@ -37,7 +38,7 @@ namespace VeinEvent
      */
     void attach(EventHandler *t_eventHandler);
 
-  signals:
+signals:
     /**
      * @brief Forwards events to the attached EventHandler
      * @param t_event
@@ -48,8 +49,11 @@ namespace VeinEvent
      */
     void sigAttached();
 
-  private:
+protected:
+    QPointer<EventHandler> m_eventHandler;
     bool m_attached = false;
-  };
+
+
+};
 }
 #endif // EVENTSYSTEM_H


### PR DESCRIPTION
All subsystems are stored inside a q set and can be deleted by thier address.
This commit is preperation for vf-cpp and improves system disassemble.

key: VeinDepDisAs (used to indentify minimum vf-event version)

Signed-off-by: bhamacher <b.hamacher@zera.de>